### PR TITLE
Update publish configuration #34

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'maven'
-    id 'com.enonic.defaults' version '1.0.3'
+    id 'maven-publish'
+    id 'com.enonic.defaults' version '1.1.0'
     id 'com.enonic.xp.app' version '1.1.0'
     id 'com.moowork.node' version '1.2.0'
 }
@@ -23,7 +23,6 @@ dependencies {
     include "com.enonic.xp:lib-portal:${xpVersion}"
     include "com.enonic.xp:lib-auth:${xpVersion}"
     include "com.enonic.xp:lib-i18n:${xpVersion}"
-    include "com.enonic.lib:lib-admin-ui:${libAdminUiVersion}"
 }
 
 node {
@@ -72,30 +71,6 @@ jar {
 }
 
 jar.outputs.dir "${buildDir}/resources/main"
-
-if ( hasProperty( 'env' ) )
-{
-    addBuildDependency()
-    applyExcludedTasks()
-}
-
-def applyExcludedTasks() {
-    def libAdminUi = gradle.includedBuild( 'lib-admin-ui' )
-    Closure permittedTasks = { it == 'lint' || it == 'test' }
-    def excludedTasks = gradle.startParameter.getExcludedTaskNames().findAll( permittedTasks )
-    libAdminUi.getLoadedSettings().getStartParameter().setExcludedTaskNames( excludedTasks )
-}
-
-def addBuildDependency() {
-    def buildTask = gradle.includedBuild( 'lib-admin-ui' ).task( ':build' )
-    def unpackDevResources = tasks.findByPath( ":unpackDevResources" )
-
-    build.dependsOn += buildTask
-    clean.dependsOn += gradle.includedBuild( 'lib-admin-ui' ).task( ':clean' )
-    flush.dependsOn += gradle.includedBuild( 'lib-admin-ui' ).task( ':flush' )
-    webpack.dependsOn += unpackDevResources
-    unpackDevResources.dependsOn += buildTask
-}
 
 def nodeEnvironment() {
     def environments = [ prod : 'production', dev: 'development' ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,5 @@
 #
 version=7.0.0-SNAPSHOT
 xpVersion=7.0.0-SNAPSHOT
-libAdminUiVersion=1.4.0-SNAPSHOT
+systemProp.org.gradle.internal.http.connectionTimeout=120000
+systemProp.org.gradle.internal.http.socketTimeout=120000

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,9 @@
 rootProject.name = 'app-main'
 
+enableFeaturePreview('STABLE_PUBLISHING')
+
 if ( hasProperty( 'env' ) ) {
     addBuild( '../xp' )
-    addBuild( '../lib-admin-ui' )
 }
 
 def addBuild( name )


### PR DESCRIPTION
Update publish configuration to use new version of `app-defaults`, `maven-publish` plugin and `publish` command, instead of maven and `uploadArchives`.
Fixed TIMEOUT exception, when resolving dependencies.
Removed `lib-admin-ui` from dependencies, since it's not included into the build.

__IMPORTANT:__ PR should be merged, when [gradle-defaults v1.1.0](https://github.com/enonic/gradle-defaults/issues/1). is published.